### PR TITLE
PR: Add table view 'redo_edits' action to the list of edit actions.

### DIFF
--- a/sardes/plugins/databases/widgets.py
+++ b/sardes/plugins/databases/widgets.py
@@ -301,7 +301,7 @@ class DatabaseConnectionWidget(QDialog):
                     'to version&nbsp;{}?'
                     ).format(db_connect_error.req_version)
                 message = (
-                    '<font color="{}">{}:</font>{}<br><br><b>{}</b>'
+                    '<font color="{}">{}: </font>{}<br><br><b>{}</b>'
                     ).format(BLUE,
                              type(db_connect_error).__name__,
                              db_connect_error,

--- a/sardes/plugins/dataio/tests/test_data_import _wizard.py
+++ b/sardes/plugins/dataio/tests/test_data_import _wizard.py
@@ -82,6 +82,9 @@ def data_import_wizard(qtbot, dbconnmanager, testfiles, mocker):
     assert not data_import_wizard.duplicates_msgbox.isVisible()
     assert not data_import_wizard.datasaved_msgbox.isVisible()
 
+    # Assert that no 'edit' actions are available in the table widget.
+    assert data_import_wizard.table_widget.tableview._actions['edit'] == []
+
     yield data_import_wizard
 
     # We need to wait for the mainwindow to close properly to avoid

--- a/sardes/widgets/tableviews.py
+++ b/sardes/widgets/tableviews.py
@@ -1652,7 +1652,7 @@ class SardesTableView(QTableView):
 
 class SardesTableWidget(SardesPaneWidget):
     EDIT_ACTIONS = ['edit_item', 'new_row', 'delete_row', 'clear_item',
-                    'save_edits', 'cancel_edits', 'undo_edits']
+                    'save_edits', 'cancel_edits', 'undo_edits', 'redo_edits']
 
     def __init__(self, table_model, parent=None, multi_columns_sort=True,
                  sections_movable=True, sections_hidable=True,


### PR DESCRIPTION
The `redo_edits` action was not listed as an edit action in the `SardesTableWidget.EDIT_ACTIONS`. This resulted in a disabled `redo_edits` action to be wrongly added in the `Data Import Wizard` as shown on the screenshot below.

![image](https://user-images.githubusercontent.com/10170372/236021525-33831c70-57e0-43e0-acbf-298515f42d08.png)
