### PR TITLE
PR: Fix failed icon in process statusbar

### DIFF
--- a/sardes/widgets/statusbar.py
+++ b/sardes/widgets/statusbar.py
@@ -12,6 +12,7 @@ import sys
 
 # ---- Third party imports
 from qtpy.QtCore import QSize, Qt, Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (QGridLayout, QLabel, QWidget, QPushButton,
                             QToolButton, QStyle, QFrame, QApplication,
                             QHBoxLayout)
@@ -148,6 +149,7 @@ class ProcessStatusBar(QWidget):
         """
         super().__init__(parent)
         self._status = self.HIDDEN
+        self._iconsize = iconsize
 
         VALIGN_DICT = {
             'center': Qt.AlignVCenter,
@@ -166,19 +168,14 @@ class ProcessStatusBar(QWidget):
 
         self._spinner = create_waitspinner(iconsize, ndots, self)
 
+        # Setup status icons.
         self._failed_icon = QLabel()
-        self._failed_icon.setPixmap(
-            get_icon('failed').pixmap(QSize(iconsize, iconsize)))
         self._failed_icon.hide()
 
         self._success_icon = QLabel()
-        self._success_icon.setPixmap(
-            get_icon('succes').pixmap(QSize(iconsize, iconsize)))
         self._success_icon.hide()
 
         self._update_icon = QLabel()
-        self._update_icon.setPixmap(
-            get_icon('update_blue').pixmap(QSize(iconsize, iconsize)))
         self._update_icon.hide()
 
         self._icons = {
@@ -187,6 +184,11 @@ class ProcessStatusBar(QWidget):
             'update': self._update_icon
             }
 
+        self.set_icon('failed', get_icon('failed'))
+        self.set_icon('success', get_icon('succes'))
+        self.set_icon('update', get_icon('update_blue'))
+
+        # Setup layout.
         layout = QGridLayout(self)
         if contents_margin is None:
             contents_margin = [0, 0, 0, 0]
@@ -242,6 +244,12 @@ class ProcessStatusBar(QWidget):
         """Hide all icons."""
         for icon in self._icons.values():
             icon.hide()
+
+    def set_icon(self, name: str, icon: QIcon):
+        """Set the icon named 'name'."""
+        self._icons[name].setPixmap(
+            icon.pixmap(QSize(self._iconsize, self._iconsize))
+            )
 
     @property
     def status(self):

--- a/sardes/widgets/statusbar.py
+++ b/sardes/widgets/statusbar.py
@@ -269,7 +269,7 @@ class ProcessStatusBar(QWidget):
     def show_fail_icon(self, message=None):
         """Stop and hide the spinner and show a failed icon instead."""
         self._status = self.PROCESS_FAILED
-        self.show_icon('fail')
+        self.show_icon('failed')
         if message is not None:
             self.set_label(message)
 

--- a/sardes/widgets/tests/test_statusbar.py
+++ b/sardes/widgets/tests/test_statusbar.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © SARDES Project Contributors
+# https://github.com/cgq-qgc/sardes
+#
+# This file is part of SARDES.
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+"""
+Tests for the buttons.py module.
+"""
+
+# ---- Standard imports
+import os.path as osp
+
+# ---- Third party imports
+import pytest
+from qtpy.QtGui import QWheelEvent
+from qtpy.QtCore import Qt, QSize, QPoint
+from qtpy.QtWidgets import QToolBar, QToolButton
+
+# ---- Local imports
+from sardes.config.gui import get_iconsize
+from sardes.widgets.statusbar import ProcessStatusBar
+
+ACTIONS = ['Action #{}'.format(i) for i in range(3)]
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture
+def pstatusbar(qtbot):
+    pstatusbar = ProcessStatusBar()
+    qtbot.addWidget(pstatusbar)
+
+    assert pstatusbar.status == pstatusbar.HIDDEN
+    assert not pstatusbar._spinner._isSpinning
+    assert not pstatusbar._spinner.isVisible()
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+    assert pstatusbar._label.text() == ''
+
+    return pstatusbar
+
+
+# =============================================================================
+# ---- Tests for the ProcessStatusBar
+# =============================================================================
+def test_pstatusbar_showhide(pstatusbar):
+    """Test the process status bar show/hide interface."""
+
+    # Show the progress status bar.
+    pstatusbar.show(message='test in progess')
+    assert pstatusbar.status == pstatusbar.IN_PROGRESS
+    assert pstatusbar._spinner._isSpinning
+    assert pstatusbar._spinner.isVisible()
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+    assert pstatusbar._label.text() == 'test in progess'
+
+    # Hide the progress status bar.
+    pstatusbar.hide()
+    assert not pstatusbar._spinner._isSpinning
+    assert not pstatusbar._spinner.isVisible()
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+
+
+def test_pstatusbar_fail_success_update(pstatusbar):
+    """
+    Test the process status bar interface to show icons is working
+    as expected.
+    """
+    # Show the progress status bar.
+    pstatusbar.show('test is spinning')
+    assert pstatusbar._spinner._isSpinning
+    assert pstatusbar._spinner.isVisible()
+    assert pstatusbar._label.text() == 'test is spinning'
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+
+    # Show the failed icon and message.
+    pstatusbar.show_fail_icon('test fail icon')
+    assert pstatusbar.status == pstatusbar.PROCESS_FAILED
+    assert not pstatusbar._spinner._isSpinning
+    assert not pstatusbar._spinner.isVisible()
+    assert pstatusbar._failed_icon.isVisible()
+    assert not pstatusbar._success_icon.isVisible()
+    assert not pstatusbar._update_icon.isVisible()
+    assert pstatusbar._label.text() == 'test fail icon'
+
+    # Show the progress status bar again.
+    pstatusbar.show('test is spinning')
+    assert pstatusbar._spinner._isSpinning
+    assert pstatusbar._spinner.isVisible()
+    assert pstatusbar._label.text() == 'test is spinning'
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+
+    # Show the success icon and message.
+    pstatusbar.show_sucess_icon('test success icon')
+    assert pstatusbar.status == pstatusbar.PROCESS_SUCCEEDED
+    assert not pstatusbar._spinner._isSpinning
+    assert not pstatusbar._spinner.isVisible()
+    assert not pstatusbar._failed_icon.isVisible()
+    assert pstatusbar._success_icon.isVisible()
+    assert not pstatusbar._update_icon.isVisible()
+    assert pstatusbar._label.text() == 'test success icon'
+
+    # Show the progress status bar again.
+    pstatusbar.show('test is spinning')
+    assert pstatusbar._spinner._isSpinning
+    assert pstatusbar._spinner.isVisible()
+    assert pstatusbar._label.text() == 'test is spinning'
+    for icon in pstatusbar._icons.values():
+        assert not icon.isVisible()
+
+    # Show the update icon and message.
+    pstatusbar.show_update_icon('test update icon')
+    assert pstatusbar.status == pstatusbar.NEED_UPDATE
+    assert not pstatusbar._spinner._isSpinning
+    assert not pstatusbar._spinner.isVisible()
+    assert not pstatusbar._failed_icon.isVisible()
+    assert not pstatusbar._success_icon.isVisible()
+    assert pstatusbar._update_icon.isVisible()
+    assert pstatusbar._label.text() == 'test update icon'
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', osp.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
Fixes #7

- Fixed a bug that prevented the `failed` icon to show properly.
- Added an interface to set the icon of a given status.
- Added tests for the `ProcessStatusBar`
