### PR TITLE
PR: Update icons that were deprecated in qtawesome 1.1

### DIFF
--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -267,8 +267,8 @@ FA_ICONS = {
         ('mdi.wrench',),
         {'color': ICON_COLOR}],
     'tooloptions': [
-        ('fa.bars',),
-        {'color': ICON_COLOR}],
+        ('mdi.menu',),
+        {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'undo': [
         ('mdi.undo-variant',),
         {'color': ICON_COLOR}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -216,8 +216,8 @@ FA_ICONS = {
         ('mdi.table-row-remove',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'reset_layout': [
-        ('fa.undo',),
-        {'color': ICON_COLOR, 'scale_factor': 1.1}],
+        ('mdi.restore',),
+        {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'save': [
         ('mdi.content-save-outline',),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -86,8 +86,8 @@ FA_ICONS = {
         ('mdi.eraser',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'exit': [
-        ('fa.power-off',),
-        {'color': ICON_COLOR}],
+        ('mdi.power',),
+        {'color': ICON_COLOR, 'scale_factor': 1.3}],
     'eye_off': [
         ('mdi.eye-off',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -258,8 +258,8 @@ FA_ICONS = {
         ('mdi.table',),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'table_columns': [
-        ('fa.columns',),
-        {'color': ICON_COLOR, 'scale_factor': 0.9, 'offset': (0, -0.1)}],
+        ('mdi.view-column-outline',),
+        {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'table_column_lock': [
         ('mdi.lock-outline',),
         {'color': ICON_COLOR}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -56,7 +56,7 @@ FA_ICONS = {
         ('mdi.close-box-outline',),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'close': [
-        ('fa.close', 'fa.close', 'fa.close'),
+        ('mdi.close-thick',),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'commit_changes': [
         ('mdi.check-circle-outline',),

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -35,8 +35,8 @@ FA_ICONS = {
         ('mdi.attachment',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'browse_files': [
-        ('fa5.folder-open',),
-        {'color': ICON_COLOR, 'scale_factor': 1}],
+        ('mdi.folder-open',),
+        {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'bug': [
         ('mdi.bug',),
         {'color': ICON_COLOR, 'scale_factor': 1.3}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -87,7 +87,7 @@ FA_ICONS = {
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'exit': [
         ('mdi.power',),
-        {'color': ICON_COLOR, 'scale_factor': 1.3}],
+        {'color': ICON_COLOR, 'scale_factor': 1.4}],
     'eye_off': [
         ('mdi.eye-off',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
@@ -219,8 +219,8 @@ FA_ICONS = {
         ('fa.undo',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'save': [
-        ('fa.save',),
-        {'color': ICON_COLOR}],
+        ('mdi.content-save-outline',),
+        {'color': ICON_COLOR, 'scale_factor': 1.2}],
     'save_to_db': [
         ('mdi.database-import',),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -58,17 +58,6 @@ FA_ICONS = {
     'close': [
         ('fa.close', 'fa.close', 'fa.close'),
         {'color': ICON_COLOR, 'scale_factor': 1.2}],
-    'close_all': [
-        ('fa.close', 'fa.close', 'fa.close'),
-        {'options': [{'scale_factor': 0.6,
-                      'offset': (0.3, -0.3),
-                      'color': ICON_COLOR},
-                     {'scale_factor': 0.6,
-                      'offset': (-0.3, -0.3),
-                      'color': ICON_COLOR},
-                     {'scale_factor': 0.6,
-                      'offset': (0.3, 0.3),
-                      'color': ICON_COLOR}]}],
     'commit_changes': [
         ('mdi.check-circle-outline',),
         {'color': GREEN, 'scale_factor': 1.2}],

--- a/sardes/widgets/logoselector.py
+++ b/sardes/widgets/logoselector.py
@@ -135,7 +135,7 @@ class LogoSelector(QWidget):
         """
         self._filename = None
         default_image = qta.icon(
-            'fa.image', color='#b3b3b3'
+            'fa5.image', color='#b3b3b3'
             ).pixmap(self.logo_size, self.logo_size)
         self.logo_preview_label.setPixmap(default_image)
         self.sig_logo_changed.emit()


### PR DESCRIPTION
Fixes #15 

Basically replaced all fa icons by mdi icons for consistency across the app.