### PR TITLE
PR: Add an About Sardes dialog to the app

### DIFF
--- a/sardes/__init__.py
+++ b/sardes/__init__.py
@@ -57,7 +57,7 @@ def get_versions(reporev=True):
         system = 'Darwin'
 
     return {
-        'version': __version__,
+        'sardes': __version__,
         'python': platform.python_version(),
         'bitness': 64 if sys.maxsize > 2**32 else 32,
         'qt': qtpy.QtCore.__version__,

--- a/sardes/app/about.py
+++ b/sardes/app/about.py
@@ -21,14 +21,14 @@ from qtpy.QtWidgets import (
 
 # ---- Local imports
 from sardes import get_versions, __rootdir__
-from gwire.config.icons import get_icon
-from gwire.config.locale import _
+from sardes.config.icons import get_icon
+from sardes.config.locale import _
 
 
 class AboutDialog(QDialog):
 
     def __init__(self, parent=None):
-        """Create About Gwire dialog with general information."""
+        """Create About Sardes dialog with general information."""
         super().__init__(parent=parent)
         self.setWindowFlags(
             self.windowFlags() & ~Qt.WindowContextHelpButtonHint)

--- a/sardes/app/about.py
+++ b/sardes/app/about.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © SARDES Project Contributors
+# https://github.com/geo-stack/sardes
+#
+# This file is part of SARDES.
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+"""About Sardes dialog."""
+
+# ---- Standard imports
+import sys
+import os.path as osp
+
+# ---- Third party imports
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import (
+    QApplication, QDialog, QDialogButtonBox, QVBoxLayout, QLabel, QFrame)
+
+# ---- Local imports
+from sardes import get_versions, __rootdir__
+from gwire.config.icons import get_icon
+from gwire.config.locale import _
+
+
+class AboutDialog(QDialog):
+
+    def __init__(self, parent=None):
+        """Create About Gwire dialog with general information."""
+        super().__init__(parent=parent)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.setWindowIcon(get_icon('information'))
+        self.setWindowTitle(_("About Sardes"))
+        versions = get_versions()
+
+        # Get current font properties
+        font = self.font()
+        font_family = font.family()
+        font_size = font.pointSize()
+        contributors = _("Sardes Project Contributors")
+        longdesc = "<p>" + _(
+            "Sardes is an open-source software designed for storing, "
+            "managing, visualizing, and interpreting data from a groundwater "
+            "monitoring network. "
+            "See the project GitHub repository for more information."
+            ""
+            ) + "</p>"
+        self.label = QLabel(_(
+            """
+            <div style='font-family: "{font_family}";
+                        font-size: {font_size}pt;
+                        font-weight: normal;
+                        '>
+            <p>
+            <br><b>Sardes {sardes_ver}</b><br>
+            Copyright &copy; {contributors}<br>
+            <a href="{website_url}">https://github.com/geo-stack/sardes</a>
+            </p>
+            <p>{longdesc}</p>
+            <p>
+            Python {python_ver} {bitness}-bit | Qt {qt_ver} |
+            {qt_api} {qt_api_ver} | {os_name} {os_ver}
+            </p>
+            </div>
+            """.format(
+                sardes_ver=versions['sardes'],
+                website_url='https://github.com/geo-stack/sardes',
+                python_ver=versions['python'],
+                bitness=versions['bitness'],
+                qt_ver=versions['qt'],
+                qt_api=versions['qt_api'],
+                qt_api_ver=versions['qt_api_ver'],
+                os_name=versions['system'],
+                os_ver=versions['release'],
+                font_family=font_family,
+                font_size=font_size,
+                contributors=contributors,
+                longdesc=longdesc
+            )
+        ))
+        self.label.setWordWrap(True)
+        self.label.setAlignment(Qt.AlignTop)
+        self.label.setOpenExternalLinks(True)
+        self.label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+
+        pixmap = QPixmap(osp.join(
+            __rootdir__, 'ressources', 'sardes_banner.png'))
+        self.label_pic = QLabel(self)
+        self.label_pic.setPixmap(
+            pixmap.scaledToWidth(450, Qt.SmoothTransformation))
+        self.label_pic.setAlignment(Qt.AlignTop)
+
+        content_frame = QFrame(self)
+        content_frame.setStyleSheet(
+            "QFrame {background-color: white}")
+        content_layout = QVBoxLayout(content_frame)
+        content_layout.addWidget(self.label_pic)
+        content_layout.addWidget(self.label)
+        content_layout.setContentsMargins(15, 15, 15, 15)
+
+        bbox = QDialogButtonBox(QDialogButtonBox.Ok)
+        bbox.accepted.connect(self.accept)
+
+        # Setup the layout.
+        layout = QVBoxLayout(self)
+        layout.addWidget(content_frame)
+        layout.addWidget(bbox)
+        layout.setSizeConstraint(layout.SetFixedSize)
+
+    def show(self):
+        """Overide Qt method."""
+        super().show()
+        self.activateWindow()
+        self.raise_()
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    about = AboutDialog()
+    about.show()
+    sys.exit(app.exec_())

--- a/sardes/app/mainwindow.py
+++ b/sardes/app/mainwindow.py
@@ -103,6 +103,10 @@ class MainWindowBase(QMainWindow):
         from sardes.app.updates import UpdatesManager
         self.updates_manager = UpdatesManager(parent=self)
 
+        # Setup the about Sardes dialog.
+        from sardes.app.about import AboutDialog
+        self.about_sardes = AboutDialog(parent=self)
+
         self.setup()
 
     def set_splash(self, message):
@@ -303,7 +307,8 @@ class MainWindowBase(QMainWindow):
         about_action = create_action(
             self, _('About Sardes...'), icon='information',
             shortcut='Ctrl+Shift+I',
-            context=Qt.ApplicationShortcut
+            context=Qt.ApplicationShortcut,
+            triggered=lambda: self.about_sardes.show()
             )
         update_action = create_action(
             self, _('Check for updates...'), icon='update',

--- a/sardes/app/mainwindow.py
+++ b/sardes/app/mainwindow.py
@@ -304,7 +304,7 @@ class MainWindowBase(QMainWindow):
             shortcut='Ctrl+Shift+R', context=Qt.ApplicationShortcut,
             triggered=lambda: QDesktopServices.openUrl(QUrl(GITHUB_ISSUES_URL))
             )
-        about_action = create_action(
+        self.about_action = create_action(
             self, _('About Sardes...'), icon='information',
             shortcut='Ctrl+Shift+I',
             context=Qt.ApplicationShortcut,
@@ -325,7 +325,7 @@ class MainWindowBase(QMainWindow):
             Separator(), self.panes_menu, self.toolbars_menu,
             self.lock_dockwidgets_and_toolbars_action,
             self.reset_window_layout_action, Separator(),
-            report_action, update_action, about_action,
+            report_action, update_action, self.about_action,
             Separator(), exit_action
             ]
         for item in options_menu_items:

--- a/sardes/app/mainwindow.py
+++ b/sardes/app/mainwindow.py
@@ -632,6 +632,8 @@ class MainWindow(MainWindowBase):
 
         self.updates_manager.start_updates_check(startup_check=True)
 
+        self.about_sardes.close()
+
 
 class ExceptHook(QObject):
     """

--- a/sardes/app/mainwindow.py
+++ b/sardes/app/mainwindow.py
@@ -444,6 +444,10 @@ class MainWindowBase(QMainWindow):
             if self.console is not None:
                 self.console.close()
 
+            # Close the About Sardes and Updates dialogs.
+            self.updates_manager.dialog.close()
+            self.about_sardes.close()
+
             # Close all internal and thirdparty plugins.
             for plugin in self.internal_plugins + self.thirdparty_plugins:
                 plugin.close_plugin()
@@ -631,8 +635,6 @@ class MainWindow(MainWindowBase):
             self.databases_plugin.connect_to_database()
 
         self.updates_manager.start_updates_check(startup_check=True)
-
-        self.about_sardes.close()
 
 
 class ExceptHook(QObject):

--- a/sardes/app/tests/test_mainwindow.py
+++ b/sardes/app/tests/test_mainwindow.py
@@ -62,6 +62,8 @@ def mainwindow(qtbot, mocker):
         if plugin.dockwindow is not None:
             assert not plugin.dockwindow.isVisible()
 
+    assert not mainwindow.about_sardes.isVisible()
+
 
 # =============================================================================
 # ---- Tests for MainWindow
@@ -102,6 +104,16 @@ def test_sardes_console(qtbot, mocker):
     with qtbot.waitSignal(mainwindow.sig_about_to_close):
         mainwindow.close()
     assert not mainwindow.console.isVisible()
+
+
+def test_about_sardes(mainwindow, qtbot, mocker):
+    """
+    Test that sardes about dialog is working as expected.
+    """
+    assert mainwindow.about_sardes is not None
+    assert not mainwindow.about_sardes.isVisible()
+    mainwindow.about_action.trigger()
+    assert mainwindow.about_sardes.isVisible()
 
 
 @pytest.mark.skipif(

--- a/sardes/config/icons.py
+++ b/sardes/config/icons.py
@@ -5,7 +5,7 @@
 #
 # This file is part of SARDES.
 # Licensed under the terms of the GNU General Public License.
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 from __future__ import annotations
 
 # ---- Standard imports
@@ -152,7 +152,7 @@ FA_ICONS = {
         ('mdi.notebook-plus-outline',),
         {'color': ICON_COLOR, 'scale_factor': 1.1}],
     'information': [
-        ('mdi.information-outline',),
+        ('mdi.information-variant',),
         {'color': ICON_COLOR, 'scale_factor': 1.3}],
     'languages': [
         ('mdi.web',),


### PR DESCRIPTION
Add a simple dialog window that show basic info about the Sardes application.

![image](https://github.com/geo-stack/sardes/assets/10170372/6c964c98-2e2a-49dd-9ec3-419de890783e)